### PR TITLE
Feat: Tune github_application_installed rule with MITRE ATT&CK

### DIFF
--- a/tools/content_manager/rules/github_application_installed.yaral
+++ b/tools/content_manager/rules/github_application_installed.yaral
@@ -42,6 +42,8 @@ rule github_application_installed {
     $principal_ip_state = array_distinct($github.principal.ip_geo_artifact.location.state)
     $principal_ip_city = array_distinct($github.principal.location.city)
     $security_result_summary = array_distinct($github.security_result.summary)
+    $mitre_attack_tactic = array_distinct("TA0003", "TA0005")
+    $mitre_attack_technique = array_distinct("T1550.001")
 
   condition:
     $github


### PR DESCRIPTION
This PR updates the `github_application_installed.yaral` rule to include MITRE ATT&CK tactics (TA0003 - Persistence, TA0005 - Defense Evasion) and technique (T1550.001 - Application Access Token) in the outcome section.